### PR TITLE
Add AI assistant option for selected text

### DIFF
--- a/src/components/popups/popupOption/component.tsx
+++ b/src/components/popups/popupOption/component.tsx
@@ -41,6 +41,10 @@ class PopupOption extends React.Component<PopupOptionProps> {
     this.props.handleMenuMode("dict");
     this.props.handleOriginalText(getSelection(this.props.currentBook.format));
   };
+  handleAssistant = () => {
+    this.props.handleMenuMode("assistant");
+    this.props.handleOriginalText(getSelection(this.props.currentBook.format));
+  };
   handleDigest = async () => {
     let bookKey = this.props.currentBook.key;
     let bookLocation = ConfigService.getObjectConfig(
@@ -254,9 +258,12 @@ class PopupOption extends React.Component<PopupOptionProps> {
                         this.handleDict();
                         break;
                       case 6:
-                        this.handleSearchInternet();
+                        this.handleAssistant();
                         break;
                       case 7:
+                        this.handleSearchInternet();
+                        break;
+                      case 8:
                         this.handleSpeak();
                         break;
                       default:

--- a/src/constants/popupList.tsx
+++ b/src/constants/popupList.tsx
@@ -5,6 +5,7 @@ export const popupList = [
   { name: "copy", title: "Copy", icon: "copy" },
   { name: "search-book", title: "Search in the Book", icon: "search-book" },
   { name: "dict", title: "Dictionary", icon: "dict" },
+  { name: "assistant", title: "AI Assistant", icon: "idea" },
   { name: "browser", title: "Search on the Internet", icon: "browser" },
   { name: "speaker", title: "Speak the text", icon: "speaker" },
 ];


### PR DESCRIPTION
## Summary
- add `assistant` entry to the popup option list
- support new `assistant` menu action

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68415b384ce083249220b6b9f4c9bc8e